### PR TITLE
Remove default value of the ax parameter

### DIFF
--- a/swarm_visualizer/barplot.py
+++ b/swarm_visualizer/barplot.py
@@ -3,24 +3,24 @@ import seaborn as sns
 from swarm_visualizer.utility.general_utils import set_axis_infos
 
 def plot_grouped_barplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
     ylim=None,
     title_str=None,
     pal=None,
-    ax=None,
     y_label=None,
 ) -> None:
     """Plots a grouped barplot. In this case, there are multiple y-var for each x-var.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
     :param ylim: y-axis limits
     :param title_str: title of the plot
     :param pal: palette
-    :param ax: axis to plot on
     :return: None.
     """
     if not pal:
@@ -40,6 +40,7 @@ def plot_grouped_barplot(
     set_axis_infos(ax, ylim=ylim, title_str=title_str)
 
 def plot_sns_grouped_barplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
@@ -47,11 +48,11 @@ def plot_sns_grouped_barplot(
     ylim=None,
     title_str=None,
     pal=None,
-    ax=None,
     y_label=None,
 ) -> None:
     """Plots a grouped barplot with sns. hue specifies the group.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
@@ -59,7 +60,6 @@ def plot_sns_grouped_barplot(
     :param ylim: y-axis limits
     :param title_str: title of the plot
     :param pal: palette
-    :param ax: axis to plot on
     :return: None.
     """
     if not pal:
@@ -81,24 +81,24 @@ def plot_sns_grouped_barplot(
 
 
 def plot_stacked_barplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
     ylim=None,
     title_str=None,
     pal=None,
-    ax=None,
     y_label=None,
 ) -> None:
     """Plots a grouped barplot.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
     :param ylim: y-axis limits
     :param title_str: title of the plot
     :param pal: palette
-    :param ax: axis to plot on
     :return: None.
     """
     if not pal:

--- a/swarm_visualizer/boxplot.py
+++ b/swarm_visualizer/boxplot.py
@@ -8,6 +8,7 @@ paired boxplot, hue is a name of a column that controls what to pair by
 
 
 def plot_paired_boxplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
@@ -16,10 +17,10 @@ def plot_paired_boxplot(
     order_list=None,
     pal=None,
     hue=None,
-    ax=None,
 ) -> None:
     """Plots a paired boxplot.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
@@ -28,7 +29,6 @@ def plot_paired_boxplot(
     :param order_list: order of the x-axis variable
     :param pal: palette
     :param hue: hue variable
-    :param ax: axis to plot on
     :return: None.
     """
     # Plots a boxplot
@@ -76,6 +76,7 @@ no pairing
 
 
 def plot_grouped_boxplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
@@ -83,10 +84,10 @@ def plot_grouped_boxplot(
     title_str=None,
     order_list=None,
     pal=None,
-    ax=None,
 ) -> None:
     """Plots a grouped boxplot.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
@@ -94,7 +95,6 @@ def plot_grouped_boxplot(
     :param title_str: title of the plot
     :param order_list: order of the x-axis variable
     :param pal: palette
-    :param ax: axis to plot on
     :return: None.
     """
     if not pal:

--- a/swarm_visualizer/histogram.py
+++ b/swarm_visualizer/histogram.py
@@ -5,14 +5,14 @@ from swarm_visualizer.utility.general_utils import set_axis_infos
 
 
 def plot_pdf(
-    data=None, xlabel: str = None, title_str: str = None, ax=None
+     ax, data=None, xlabel: str = None, title_str: str = None
 ) -> None:
     """Plot PDF of a data.
 
+    :param ax: axis to plot
     :param data: data to plot
     :param xlabel: x-axis label
     :param title_str: title of the plot
-    :param ax: axis to plot on
     :return: None.
     """
     # Convert data to numpy array
@@ -37,6 +37,7 @@ def plot_pdf(
 
 
 def plot_several_pdf(
+    ax,
     data_list=None,
     xlabel: str = None,
     title_str: str = None,
@@ -44,10 +45,10 @@ def plot_several_pdf(
     ylabel: str = None,
     xlim=None,
     kde: bool = False,
-    ax=None,
 ) -> None:
     """Plot PDF of a data list.
 
+    :param ax: axis to plot on
     :param data_list: data list
     :param xlabel: x-axis label
     :param title_str: title of the plot
@@ -55,7 +56,6 @@ def plot_several_pdf(
     :param ylabel: y-axis label
     :param xlim: x-axis limits
     :param kde: whether to plot kde
-    :param ax: axis to plot on
     :return: None.
     """
     for i, data in enumerate(data_list):

--- a/swarm_visualizer/lineplot.py
+++ b/swarm_visualizer/lineplot.py
@@ -6,23 +6,23 @@ from swarm_visualizer.utility.general_utils import set_axis_infos
 
 
 def plot_basic_lineplot(
+    ax,
     y=None,
     title_str: str = None,
     ylabel: str = None,
     lw: float = 3.0,
     ylim=None,
     xlabel: str = "x",
-    ax=None,
 ) -> None:
     """Basic lineplot.
 
+    :param ax: axis to plot on
     :param y: y data to plot
     :param title_str: title of the plot
     :param ylabel: y-axis label
     :param lw: line width
     :param ylim: y-axis limits
     :param xlabel: x-axis label
-    :param ax: axis to plot on
     :return: None.
     """
     # Plot time series
@@ -34,6 +34,7 @@ def plot_basic_lineplot(
 
 
 def plot_overlaid_lineplot(
+    ax,
     normalized_dict: Dict = None,
     title_str: str = None,
     ylabel: str = None,
@@ -44,10 +45,10 @@ def plot_overlaid_lineplot(
     legend_present: bool = True,
     DEFAULT_MARKERSIZE: float = 15,
     delete_yticks: bool = False,
-    ax=None,
 ) -> None:
     """Overlaid line plot.
     
+    :param ax: axis to plot on
     :param normalized_dict: dictionary with values to plot
     :param title_str: title of the plot
     :param ylabel: y-axis label
@@ -58,7 +59,6 @@ def plot_overlaid_lineplot(
     :param legend_present: whether to plot the legend
     :param DEFAULT_MARKERSIZE: default marker size
     :param delete_yticks: whether to delete the y-axis ticks
-    :param ax: axis to plot on
     :return: None.
     """
     # dictionary:

--- a/swarm_visualizer/scatterplot.py
+++ b/swarm_visualizer/scatterplot.py
@@ -5,6 +5,7 @@ from swarm_visualizer.utility.general_utils import set_axis_infos
 
 
 def plot_basic_scatterplot(
+    ax,
     x=None,
     y=None,
     title_str: str = None,
@@ -15,10 +16,10 @@ def plot_basic_scatterplot(
     xlim=None,
     ms: float = 4.0,
     color: str = "b",
-    ax=None,
 ) -> None:
     """Basic scatter plot.
 
+    :param ax: axis to plot
     :param x: x-axis data
     :param y: y-axis data
     :param title_str: title of the plot
@@ -29,9 +30,11 @@ def plot_basic_scatterplot(
     :param xlim: x-axis limits
     :param ms: marker size
     :param color: color of the markers
-    :param ax: axis to plot
     :return: None.
     """
+    if ax is None:
+        fig, ax = plt.subplots()
+
     # Scatter plot
     ax.scatter(x, y, lw=lw, s=ms, color=color)
 
@@ -48,8 +51,10 @@ def plot_basic_scatterplot(
     # Set axis infos
     set_axis_infos(ax, ylim=ylim, title_str=title_str)
 
+    return ax
 
-# joint plot: scatterplot with the CDFs
+
+# joint plot: scatterplot with the PDFs
 def plot_scatter_pdf_plot(
     x=None,
     y=None,

--- a/swarm_visualizer/utility/statistics_utils.py
+++ b/swarm_visualizer/utility/statistics_utils.py
@@ -3,12 +3,12 @@ from statannotations.Annotator import Annotator
 
 
 def add_wilcoxon_value(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
     hue=None,
     order_list=None,
-    ax=None,
     box_pairs=None,
     test_type=None,
     text_format=None,

--- a/swarm_visualizer/violinplot.py
+++ b/swarm_visualizer/violinplot.py
@@ -4,6 +4,7 @@ from swarm_visualizer.utility.general_utils import set_axis_infos
 
 
 def plot_grouped_violinplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
@@ -11,10 +12,10 @@ def plot_grouped_violinplot(
     title_str=None,
     order_list=None,
     pal=None,
-    ax=None,
 ) -> None:
     """Plots a grouped violinplot.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
@@ -22,7 +23,6 @@ def plot_grouped_violinplot(
     :param title_str: title of the plot
     :param order_list: order of the x-axis variable
     :param pal: palette
-    :param ax: axis to plot on
     :return: None.
     """
     # Plots a violinplot
@@ -48,6 +48,7 @@ def plot_grouped_violinplot(
 
 
 def plot_paired_violinplot(
+    ax,
     df=None,
     x_var=None,
     y_var=None,
@@ -56,10 +57,10 @@ def plot_paired_violinplot(
     order_list=None,
     pal=None,
     hue=None,
-    ax=None,
 ) -> None:
     """Plots a paired boxplot.
 
+    :param ax: axis to plot on
     :param df: dataframe
     :param x_var: x-axis variable
     :param y_var: y-axis variable
@@ -68,7 +69,6 @@ def plot_paired_violinplot(
     :param order_list: order of the x-axis variable
     :param pal: palette
     :param hue: hue variable
-    :param ax: axis to plot on
     :return: None.
     """
     # Plots a boxplot

--- a/tests/test_scatterplot.py
+++ b/tests/test_scatterplot.py
@@ -36,6 +36,7 @@ def test_basic_scatterplot(x_data, y_data) -> None:
 
     # Create a  basic scatter plot
     plot_basic_scatterplot(
+        ax,
         x=x_data,
         y=y_data,
         title_str="Basic Scatter Plot",
@@ -46,7 +47,6 @@ def test_basic_scatterplot(x_data, y_data) -> None:
         xlim=None,
         ms=10.0,
         color="b",
-        ax=ax,
     )
 
     # Save the plot


### PR DESCRIPTION
For most functions, we need to specify the ax parameter.
However, it is defaulted as None, so the users often forget to pass a value to it.
I have removed the ax parameter's default value and made it a user-specific non-default parameter.